### PR TITLE
Remove commas between number, month, and year

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,7 +14,7 @@
           <div class="row post-desc">
             <div class="col-xs-6">
               <time class="post-date" datetime="{{ .Date.Format "2006-01-02 15:04:05 MST" }}">
-                {{ .Date.Format "02, Jan, 2006" }}
+                {{ .Date.Format "02 Jan 2006" }}
               </time>
             </div>
             <div class="col-xs-6">


### PR DESCRIPTION
When using the date format `2 Jan 2006`, there are no commas used.

When using a format such as `Jan 2, 2006` the comma is added to separate the numbers.