### PR TITLE
Hide the author attribution if no author specified

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,11 +17,13 @@
                 {{ .Date.Format "02, Jan, 2006" }}
               </time>
             </div>
+            {{ if .Site.Author.name }}
             <div class="col-xs-6">
               <div class="post-author">
                 <a target="_blank" href="{{ .Site.Author.homepage }}">@{{ .Site.Author.name }}</a>
               </div>
             </div>
+            {{ end }}
           </div>
         </header>
 


### PR DESCRIPTION
In the current implementation, if an author is not specified, the `@` is still displayed.

This change hides the section entirely if a site author name is not specified in config.