### PR TITLE
Hide date for posts which don't specify them

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,9 +13,11 @@
           <h1 class="post-title">{{ .Title }}</h1>
           <div class="row post-desc">
             <div class="col-xs-6">
+              {{ if .Date }}
               <time class="post-date" datetime="{{ .Date.Format "2006-01-02 15:04:05 MST" }}">
                 {{ .Date.Format "02, Jan, 2006" }}
               </time>
+              {{ end }}
             </div>
             <div class="col-xs-6">
               <div class="post-author">


### PR DESCRIPTION
In some cases, such as an "About" page, you don't want to specify a date,
as it's supposed to be permanent. If you don't specify a date in that page,
the unconditional code here specifies a default date of `01 Jan 0001`,
which is certainly not what we want.