### PR TITLE
fix: post-category href

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -40,7 +40,7 @@
           <div class="col-xs-12">
             {{ range .Params.categories }}
             <div class="post-category">
-              <a href="/{{ site.LanguagePrefix }}/categories/{{ lower . }}/">
+              <a href="{{ site.LanguagePrefix }}/categories/{{ lower . }}/">
                 {{ . }}
               </a>
             </div>


### PR DESCRIPTION
post-category 的 href 多了一个 / 号，导致页面上的 url 不正确。

![image-20200827233232694](https://gitee.com/quanuanc/PicGo-IMG/raw/master/image-20200827233232694.png)