### PR TITLE
Add (optional) support for Twitter Cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ extraHead = '<script src="xxxx.js"></script>'
 extraCSSFiles = ["css/foo.css", "css/bar.css"]
 ```
 
+### Twitter Cards
+
+Add the following setting:
+
+```
+[params]
+twitterCards = true
+```
+
+In a post's front matter, include a keyword `images` with a value of a list of
+URLs of images that will be used for Twitter Cards.
+
 ### Insert content on every post
 
 ```

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -63,5 +63,6 @@
     (function (undefined) { }).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});
   </script> -->
 
+  {{ if .Site.Params.TwitterCards }}{{ template "_internal/twitter_cards.html" . }}{{ end }}
   {{ .Site.Params.extraHead | safeHTML }}
 </head>


### PR DESCRIPTION
This is a built-in feature of Hugo that we're enabling in the theme.

Add `twitterCards = true` in the `[params]` section to enable it; for
 more info, see: https://gohugo.io/templates/internal/#twitter-cards