### PR TITLE
feat: dark mode

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -14,3 +14,24 @@
     // priority: true,
   // });
 </script>
+<script src="https://cdn.staticfile.org/Darkmode.js/1.5.7/darkmode-js.min.js"></script>
+<script>
+    function addDarkModeWidget() {
+        const options = {
+            bottom: '64px', // default: '32px'
+            right: '32px', // default: '32px'
+            // left: '32px', // default: 'unset'
+            time: '0.5s', // default: '0.3s'
+            mixColor: '#fff', // default: '#fff'
+            backgroundColor: '#fff',  // default: '#fff'
+            buttonColorDark: '#100f2c',  // default: '#100f2c'
+            buttonColorLight: '#fff', // default: '#fff'
+            saveInCookies: true, // default: true,
+            label: '🌓', // default: ''
+            autoMatchOsTheme: true // default: true
+        }
+        const darkmode = new Darkmode(options);
+        darkmode.showWidget();
+    }
+    window.addEventListener('load', addDarkModeWidget);
+</script>


### PR DESCRIPTION
This PR adds a feature that allows users to switch between light mode and dark mode with a minimal amount of code. It utilizes the Darkmode.js library, which can be accessed at https://darkmodejs.learn.uno/.

![](https://github.com/joway/hugo-theme-yinyang/assets/27894831/66c6ecfb-f735-4ccd-9e96-8b1005aff472)
![](https://github.com/joway/hugo-theme-yinyang/assets/27894831/1cc054d1-a0bf-4ee7-b3db-17d5745c1dad)
