### PR TITLE
feat: add paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,12 @@ DefaultContentLanguage = "cn"
     languageName = "Chinese"
     weight = 2
 
+[taxonomies]
+year = "years"
+
 [params]
 mainSections = ["posts"]
+postLimitPerYear = 10 # Number of articles combined limit for the current year
 headTitle = "Joway Wang"
 disqus = "joway" # disqus account name
 extraHead = '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-xxx"></script>'

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,2 +1,7 @@
 +++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ now.Format "2006-01-02 15:04:05" }}
+years: ["{{ now.Format "2006" }}"]
+categories: []
+tags: []
 +++

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -46,14 +46,26 @@ a:hover {
 .markdown-body pre {
   padding: 16px;
   overflow: auto;
+  font-size: 70%;
+  line-height: 120%;
   border-radius: 10px;
 }
 
 .markdown-body code {
   padding: 0.2em 0.4em;
   font-size: 85%;
-  background-color: #f6f8fa;
+  background-color: #b6b6b6;
   border-radius: 6px;
+}
+
+table {
+  border-collapse: collapse;
+  vertical-align: middle;
+  text-align: center;
+}
+
+thead, th, td, tr {
+  border: 1px solid #b6b6b6;
 }
 
 /* reset code */

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,12 +17,21 @@
             {{ range .Pages }}
             <div class="row posts-line">
               <div class="posts-date col-xs-2">
-                <time datetime="{{ .Date.Format "2006-01-02 15:04:05 MST" }}">{{ .Date.Format "Jan 02"}}</time>
+                <time datetime="{{ .Date.Format " 2006-01-02 15:04:05 MST" }}">{{ .Date.Format "Jan 02"}}</time>
               </div>
-              <div class="posts-title col-xs-10">
+              <div class="posts-title col-xs-9 col-sm-10">
                 <div class="row">
-                  <div class="col-xs-12">
+                  <div class="col-xs-11 col-sm-10">
                     <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                  </div>
+                  <div class="col-xs-1 col-sm-2 posts-categories">
+                    {{ if .Params.categories }}
+                    <div class="posts-category">
+                      <a href="/categories/{{ lower (index .Params.categories 0) }}/">
+                        <strong>{{ index .Params.categories 0 }}</strong>
+                      </a>
+                    </div>
+                    {{ end }}
                   </div>
                 </div>
               </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,14 +8,19 @@
       <div class="col-xs-12">
         {{ partial "header.html" . }}
         <div id="posts-list">
-          {{ range (where site.RegularPages "Type" "in" site.Params.mainSections).GroupByDate "2006" -}}
+          {{ $defaultLimit := 10 }}
+          {{ $postLimit := default $defaultLimit .Site.Params.postLimitPerYear }}
+
+          {{ range (where site.RegularPages "Type" "in" site.Params.mainSections).GroupByDate "2006" }}
           <section>
             <h1 class="site-date-catalog">{{ .Key }}</h1>
+            {{ $yearCount := 0 }}
 
             {{ range .Pages }}
+            {{ if lt $yearCount $postLimit }}
             <div class="row posts-line">
               <div class="posts-date col-xs-3 col-sm-2">
-                <time datetime="{{ .Date.Format "2006-01-02 15:04:05 MST" }}">{{ .Date.Format "Jan 02"}}</time>
+                <time datetime="{{ .Date.Format " 2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "Jan 02"}}</time>
               </div>
               <div class="posts-title col-xs-9 col-sm-10">
                 <div class="row">
@@ -23,13 +28,25 @@
                     <a href="{{ .RelPermalink }}">{{ .Title }}</a>
                   </div>
                   <div class="col-xs-1 col-sm-2 posts-categories">
-                    {{ range .Params.categories }}
+                    {{ if .Params.categories }}
                     <div class="posts-category">
-                      <a href="/categories/{{ lower . }}/"><strong>{{ . }}</strong></a>
+                      <a href="/categories/{{ lower (index .Params.categories 0) }}/">
+                        <strong>{{ index .Params.categories 0 }}</strong>
+                      </a>
                     </div>
                     {{ end }}
                   </div>
                 </div>
+              </div>
+            </div>
+            {{ $yearCount = add $yearCount 1 }}
+            {{ end }}
+            {{ end }}
+
+            {{ if gt (len .Pages) $postLimit }}
+            <div class="row">
+              <div class="col-xs-12 text-center" style="text-align: center;">
+                <a href="/years/{{ .Key | urlize }}/">查看更多>></a>
               </div>
             </div>
             {{ end }}

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,3 +1,4 @@
+{{ if .Site.Params.disqus_enabled }}
 <div id="disqus_thread"></div>
 <script>
   window.addEventListener("load", () => {
@@ -17,3 +18,4 @@
     >comments powered by Disqus.</a
   ></noscript
 >
+{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
 </div>
 <div class="row">
   {{ range .Site.Languages -}} {{ if ne .LanguageName $curLanguageName }}
-  <div class="lang-switch col-xs-3 col-xs-offset-9">
+  <div class="lang-switch col-xs-3 col-xs-offset-9 end-md">
     <a href="/{{ .Lang }}/">{{ .LanguageName }}</a>
   </div>
   {{ end }} {{ end }}


### PR DESCRIPTION
新增：
对当前年份下的文章进行折叠展示，而不是全部展示(点击查看更多按钮展示所有)。默认10篇，可在`hugo.toml`中通过参数`postLimitPerYear`修改

优化:
对代码字体大小进行优化。当前代码字体和正文字体大小相同，长代码影响观感，将代码字体缩小为75%