### PR TITLE
docs README: replace clone with submodule for theme installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 From the root of your site:
 
 ```shell
-git clone git@github.com:joway/hugo-theme-yinyang.git themes/yinyang
+git submodule add https://github.com/joway/hugo-theme-yinyang.git themes/yinyang
 ```
 
 Change `config.toml`:


### PR DESCRIPTION
The official quick start now uses submodule as the method for installing themes.
Ref: https://gohugo.io/getting-started/quick-start/